### PR TITLE
Connection bug

### DIFF
--- a/dwisc.py
+++ b/dwisc.py
@@ -158,7 +158,7 @@ def main(args):
             except Exception as error:
                 print_err(error)
                 print_err('resubmitting round')
-                #revert to solutions before start of previous round
+                #revert to solutions at start of previous round
                 if solutions_prev is None:
                     solutions_all = None
                 else:


### PR DESCRIPTION
I was experiencing a connection error which caused the majority of my submitted jobs to fail.  I made changes to handle this exception with a try/catch block that resubmits the round that caused the exception.  I save the state of the solutions dictionary before each round so that if there is a connection error in the middle of the round, the round can be resubmitted without double counting.  Also, occasionally the Dwave server never responded to my submitted jobs causing the program to hang indefinitely, and so I put a timeout limit for waiting for the response.  This also throws an exception within the try/catch block which will cause the round to be resubmitted.  @ccoffrin 